### PR TITLE
Use specific version of idasen-controller

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apt install bluez -y
 
 RUN apt install build-essential libglib2.0-dev libical-dev libreadline-dev libudev-dev libdbus-1-dev libdbus-glib-1-dev bluetooth libbluetooth-dev usbutils -y
 
-RUN pip3 install idasen-controller
+RUN pip3 install idasen-controller==2.0.0
 
 RUN apt install curl -y
 


### PR DESCRIPTION
To prevent accidentally getting breaking updates (such as in 2.0.0), fixate the version of idasen-controller